### PR TITLE
Feature/156902263 remove superfluous markup

### DIFF
--- a/__test__/__snapshots__/BioentityProperty.test.js.snap
+++ b/__test__/__snapshots__/BioentityProperty.test.js.snap
@@ -10,9 +10,7 @@ exports[`BioentityProperty with data matches snapshot 1`] = `
     >
       Link of relevance 1
     </a>
-    <span>
-      , 
-    </span>
+    , 
   </span>
   <span>
     <a
@@ -22,9 +20,7 @@ exports[`BioentityProperty with data matches snapshot 1`] = `
     >
       a Link of relevance 2
     </a>
-    <span>
-      , 
-    </span>
+    , 
   </span>
   <span>
     <a
@@ -34,6 +30,7 @@ exports[`BioentityProperty with data matches snapshot 1`] = `
     >
       Link of relevance 3
     </a>
+    
   </span>
   <a
     onClick={[Function]}

--- a/src/BioentityProperty.js
+++ b/src/BioentityProperty.js
@@ -3,18 +3,13 @@ import PropTypes from 'prop-types'
 
 
 const PropertyValue = ({hasUrl, isLast, text, url}) =>
-  <span>
-    {hasUrl ? (
-        <a className={"bioEntityCardLink"} href={url} target="_blank">{text}</a>
-      ) : (
-        <span>{text}</span>
-      )
-    }
-
-    {!isLast &&
-      <span>, </span>
-    }
-    </span>
+   hasUrl ?
+      <span>
+        <a className={"bioEntityCardLink"} href={url} target="_blank">{text}</a>{!isLast ? `, ` : ``}
+      </span> :
+      <span>
+        {text + (!isLast ? `, ` : ``)}
+      </span>
 
 const TOP_RELEVANT_VALUES = 3
 


### PR DESCRIPTION
The second `<span>` in `PropertyValue` is optional ([since React 16 we can return strings](https://reactjs.org/blog/2017/09/26/react-v16.0.html#new-render-return-types-fragments-and-strings)) but I still think having a wrapping  `<span>` this is better.